### PR TITLE
Remove fab modules deployment as it is already part of core RC deploy…

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -114,7 +114,6 @@ def deploy(name,force=""):
     move_edocs_folder()
     utility_redcap.set_redcap_base_url()
     utility_redcap.set_hook_functions_file()
-    utility_redcap.deploy_external_modules()
     force_deployment_of_redcap_cron = utility.is_affirmative(force)
     configure_redcap_cron(env.deploy_redcap_cron, force_deployment_of_redcap_cron)
     utility_redcap.test()

--- a/utility_redcap.py
+++ b/utility_redcap.py
@@ -118,11 +118,3 @@ def test(warn_only=False):
             return(True)
 
 
-def deploy_external_modules(relative_path_to_install_sql="external_modules/sql/create\ tables.sql"):
-    """
-    Run the external_modules/create tables.sql file to build its tables
-    """
-    absolute_path_to_install_sql = '/'.join([env.live_project_full_path, relative_path_to_install_sql])
-    utility.apply_remote_sql_to_db(absolute_path_to_install_sql)
-
-


### PR DESCRIPTION
The deployment of modules is done automatically as part of RC core deployment, i.e., the `redcap_external_modules` table is created in `redcap_v7.6.9/Resources/sql/install.sql`. Hence, we no longer need to deploy the modules 'manually'. 

On the other hand, the test
`test -e /var/www/redcap/external_modules/sql/create\ tables.sql`
is failing since there is no file in `/var/www/redcap/external_modules/sql/create\ tables.sql`.

This PR fixes both issues.