### PR TITLE
Autonotify3 plugin

### DIFF
--- a/deploy/plugins/autonotify3/99-<instance_name>-autonotify3.conf.example
+++ b/deploy/plugins/autonotify3/99-<instance_name>-autonotify3.conf.example
@@ -1,0 +1,8 @@
+<Location /<instance_name>/plugins/autonotify3/index.php>
+  Order Allow,Deny
+  Allow from 10.4.117.100 159.178.62.115
+  Satisfy Any   
+  AuthType shibboleth
+  ShibUseHeaders On
+  require shibboleth 
+</Location>

--- a/deploy/plugins/autonotify3/ORIGIN.md
+++ b/deploy/plugins/autonotify3/ORIGIN.md
@@ -1,0 +1,7 @@
+# AutoNotify3 Plugin
+
+* Source: https://github.com/123andy/redcap-autonotify3.git
+* Author: Andy Martin
+* Last updated:
+* Version: Unknown
+* License: GPL

--- a/deploy/plugins/autonotify3/README-deploy.md
+++ b/deploy/plugins/autonotify3/README-deploy.md
@@ -1,0 +1,6 @@
+# Deployment README for the REDCap Autonotify3 Plugin
+
+The `deploy.sh` script in this can make most of the changes needed to deploy this plugin on a Debian Linux host using apache to host REDCap.
+However, the data event trigger will need unauthenticated access to index.php. To turn off authentication for this page, you can use the apache configuration file `99-<instance_name>-autonotify3.conf.example` as an example. This file is tailored to a shibboleth environment and has IPs that will not apply to your environment even if you do have shibboleth. You will need to adapt this file for your site's needs.
+
+The `post-deploy.sh` script creates a folder `/etc/apache2/ssl-includes/` and adds a directive in the apache ssl file to include all `*.conf` files in `/etc/apache2/ssl-includes/`.  Place the `99-<instance_name>-autonotify3.conf` for your environment in `/etc/apache2/ssl-includes/` and restart apache to test the new directives.

--- a/deploy/plugins/autonotify3/deploy.sh
+++ b/deploy/plugins/autonotify3/deploy.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+export MYTARGETDIR=$1
+
+# determine the directory where this script resides
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# get source files
+TEMPDIR=`mktemp -d`
+git clone https://github.com/123andy/redcap-autonotify3.git $TEMPDIR
+
+# copy files to the correct target locations
+mkdir -p $MYTARGETDIR
+cp $TEMPDIR/index.php $MYTARGETDIR
+cp $TEMPDIR/common.php $MYTARGETDIR
+cp $TEMPDIR/Utility.php $MYTARGETDIR
+cp $TEMPDIR/cron.php $MYTARGETDIR
+cp $TEMPDIR/EnhancedPiping.php $MYTARGETDIR
+
+rm -rf $TEMPDIR

--- a/deploy/plugins/autonotify3/post-deploy.sh
+++ b/deploy/plugins/autonotify3/post-deploy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Make a directory for supplementary SSL configuration details
+SSL_INCLUDES=/etc/apache2/ssl-includes
+if [ ! -e $SSL_INCLUDES ]; then
+    mkdir -p $SSL_INCLUDES
+fi
+
+# make sure the above SSL_INCLUDES directory is referenced in the apache ssl config
+SSL_CONFIG=/etc/apache2/sites-available/default-ssl.conf
+if [ -e $SSL_CONFIG ]; then
+    if [ `grep -c "Include ssl-includes/" $SSL_CONFIG` == 0 ] ; then
+        echo "WARNING: the line 'Include ssl-includes/' does not existing in $SSL_CONFIG.  Please fix this."
+    fi
+else
+    echo "Error: I don't know where the SSL configuration file is.  Exiting!"
+    exit
+fi
+
+# place our apache directives in the SSL_INCLUDES directory
+if [ ! $SHIB == "0" ]; then
+    cp $DIR/autonotify.conf $SSL_INCLUDES/
+    service apache2 restart
+fi
+
+# Alert the admin to turn on DET for the REDCAP system
+echo "$DIR: Please turn on DET for this REDCap instance"

--- a/deploy/plugins/autonotify3/test.sh
+++ b/deploy/plugins/autonotify3/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+# Run tests if any


### PR DESCRIPTION
- A project called [Testing Autonotify3](https://redcapstage.ctsi.ufl.edu/redcapb/redcap_v7.6.9/ProjectSetup/index.php?pid=3696) with `pid = 3696` has already been added to [redcapb](https://redcapstage.ctsi.ufl.edu/redcapb) to facilitate testing. The **autonotify3** plugin works similarly to the **autonotify2** plugin.

- Please make sure to check the apache configuration file `deploy/plugins/autonotify3/99-<instance_name>-autonotify3.conf.example`.

- Bookmark configuration example:
<img width="851" alt="bookmark" src="https://user-images.githubusercontent.com/8559654/32730977-9b10f754-c856-11e7-8577-491597bc41cf.png">

- Setup example:
<img width="974" alt="configuration" src="https://user-images.githubusercontent.com/8559654/32730785-22c6d00c-c856-11e7-9eaa-5dcd53bec24f.png">
