### PR TITLE
Adjust module version numbers and expand the list of examples

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -32,6 +32,8 @@ SHARED_FOLDER=/vagrant
 # Pick a fast mirror...or at least one that works
 log "Picking a fast mirror in the US..."
 apt-get install -y netselect-apt
+# patch netselect-apt to avoid redirect failures
+sed -e 's#url="http://www.debian.org/mirror/mirrors_full"#url="https://www.debian.org/mirror/mirrors_full"#;' -i /usr/bin/netselect-apt
 cd /etc/apt/
 netselect-apt -c US > ~/netselect-apt.log 2>&1
 

--- a/deploy/modules.json.example
+++ b/deploy/modules.json.example
@@ -1,7 +1,7 @@
 [
     {
         "name": "linear_data_entry_workflow",
-        "version": "2.0.0",
+        "version": "2.0",
         "repo": "https://github.com/ctsit/linear_data_entry_workflow.git",
         "branch": "develop"
     }

--- a/deploy/modules.json.example
+++ b/deploy/modules.json.example
@@ -4,5 +4,26 @@
         "version": "2.0",
         "repo": "https://github.com/ctsit/linear_data_entry_workflow.git",
         "branch": "develop"
+    },
+
+    {
+        "name": "redcap_user_profile",
+        "version": "1.0",
+        "repo": "https://github.com/ctsit/redcap_user_profile.git",
+        "branch": "develop"
+    },
+
+    {
+        "name": "redcap-survey-link-lookup",
+        "version": "1.0",
+        "repo": "https://github.com/lsgs/redcap-survey-link-lookup.git",
+        "branch": "master"
+    },
+
+    {
+        "name": "auto_populate_fields",
+        "version": "2.0",
+        "repo": "https://github.com/ctsit/auto_populate_fields.git",
+        "branch": "develop"
     }
 ]


### PR DESCRIPTION
Adjust module version numbers in the sample modules.json configuration file to comply with issues in the current REDCap external modules code.  At the same time expand the list of examples to include some real-world examples on Github.

Also repair an issue affecting netselect-apt. It was failing to follow redirect requests from http to https. To address is, a stream edit directs netselect-apt to use https from the very first request.