### PR TITLE
Fixing composer dependencies installation

### DIFF
--- a/deploy/composer/deploy.sh
+++ b/deploy/composer/deploy.sh
@@ -3,23 +3,18 @@ set -e
 
 export MYTARGETDIR=$1
 
+cp composer.json $MYTARGETDIR
+cd $MYTARGETDIR
+
 # download composer installer
-TEMPDIR=`mktemp -d`
-php -r "copy('https://getcomposer.org/installer', '$TEMPDIR/composer-setup.php');"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 
 # install composer
-php $TEMPDIR/composer-setup.php --install-dir=$TEMPDIR
+php composer-setup.php
 
 # install dependencies
-cp composer.json $TEMPDIR
-COMPOSER=$TEMPDIR/composer.json $TEMPDIR/composer.phar install -d $TEMPDIR
+php composer.phar install
 
 # removing install files
-rm $TEMPDIR/composer-setup.php
-rm $TEMPDIR/composer.phar
-
-# copying composer.json, composer.lock and vendor folder to the final location
-cp -r $TEMPDIR/* $MYTARGETDIR
-
-# removing temporary folder
-rm -rf $TEMPDIR
+rm composer-setup.php
+rm composer.phar


### PR DESCRIPTION
Review steps:
- [x] Make sure your `deploy/modules.json` file contains Send Rx
- [x] Open `settings/vagrant.ini` file and make sure `modules_deployment_source` variable equals `deploy/modules.json`
- [x] From your project root, run `fab vagrant package:redcap<REDCap version>.zip`
- [x] Run `ls build/redcap/vendor` and make sure you see `mpdf` folder in the list