### PR TITLE
Add a cron task to deploy.py

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -85,6 +85,12 @@ def move_edocs_folder():
                     if file_name == "index.html":
                         run('rm -r %s' % default_edoc_path)
 
+@task()
+def cron(deploy=True, force_deployment_of_redcap_cron= True):
+    """
+    Deploy the REDCap Cron task.
+    """
+    configure_redcap_cron(deploy, force_deployment_of_redcap_cron)
 
 def configure_redcap_cron(deploy=False, force_deployment_of_redcap_cron=False):
     crond_for_redcap = '/etc/cron.d/%s' % env.project_path


### PR DESCRIPTION
Testing procedure

- [x] Run the `fab --list` command. Verify a task named "deploy.cron" is listed.
- [x] Connect to the local test VM named "vagrant" with `vagrant ssh`.  Check for a file "/etc/cron.d/redcap". If found, delete it.
- [x] Outside of the VM, recreate the cron file with the new task by running `fab vagrant deploy.cron`
- [x] Connect to the local test VM with `vagrant ssh`.  Verify the file "/etc/cron.d/redcap" exists.
- [x] Use your web browser to access the Control Panel of your REDCap test instance. Verify there is no alert about the Cron task no running on the Configuration Check page.
