### PR TITLE
Exclude database.php from deployment during upgrade processes

### DIFF
--- a/upgrade.py
+++ b/upgrade.py
@@ -15,9 +15,10 @@ def upgrade(name):
     as packaged by this fabfile
     """
 
+    upgrade = True
     utility_redcap.make_upload_target()
     copy_running_code_to_backup_dir()
-    utility_redcap.upload_package_and_extract(name)
+    utility_redcap.upload_package_and_extract(name, upgrade)
     utility.write_remote_my_cnf()
     offline()
     utility_redcap.move_software_to_live()

--- a/utility_redcap.py
+++ b/utility_redcap.py
@@ -30,7 +30,7 @@ def make_upload_target():
         run("mkdir -p %(upload_target_backup_dir)s" % env)
 
 
-def upload_package_and_extract(name):
+def upload_package_and_extract(name, upgrade=False):
     """
     Upload the redcap package and extract it into the directory from which new
     software will be deployed, e.g., /var/www.backup/redcap-20160117T1543/
@@ -50,7 +50,13 @@ def upload_package_and_extract(name):
         with settings(warn_only=True):
             if run('test -d %s/webtools2/pdf/font/unifont' % env.upload_target_backup_dir).succeeded:
                 run('chmod ug+w %s/webtools2/pdf/font/unifont/*' % env.upload_target_backup_dir)
-        run('rsync -rc %s/redcap/* %s' % (temp2, env.upload_target_backup_dir))
+        # Write the new code on top of the existing code
+        if upgrade == False:
+            run('rsync -rc %s/redcap/* %s' % (temp2, env.upload_target_backup_dir))
+        else:
+            # exclude some files during upgrades
+            exclusions = "--exclude=database.php"
+            run('rsync -rc %s %s/redcap/* %s' % (exclusions, temp2, env.upload_target_backup_dir))
         # make sure the temp file directory in redcap web space will be writeable
         run('chmod -R g+w %s/temp' % env.upload_target_backup_dir)
         # Remove the temp directories
@@ -111,5 +117,3 @@ def test(warn_only=False):
                 abort("One or more tests failed.")
         else:
             return(True)
-
-


### PR DESCRIPTION
Fixes issue #42. 

To test this change, follow these steps:

- [x] Package any redcap*.zip--but not the latest--and deploy it to a redcap instance. 
- [x] Verify it deployed correctly
- [x] Package any redcap8.4.0_upgrade.zip or higher and upgrade the aforementioned redcap instance. 
- [x] Verify redcap still works and that you got the upgrade.

If you have a deploy/upgrade failure, check the contents/existence of database.php, a sibling to the redcap_vX.Y.Z code directories.