### PR TITLE
Change sync type to nsf as nsf causes other issues.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,10 @@ Vagrant.configure(2) do |config|
   config.hostsupdater.remove_on_suspend = false
   config.hostsupdater.aliases = [ENV["HOSTNAME_IN_HOST"]]
 
-  config.vm.synced_folder ".", "/vagrant", type: "nfs"
+  config.vm.synced_folder ".", "/vagrant", type: "virtualbox",
+    owner: "vagrant",
+    group: "www-data",
+    mount_options: ["dmode=775,fmode=774"]
 
   config.vm.provider "virtualbox" do |vb|
     # vb.memory = "1024"


### PR DESCRIPTION
Although the sync of shared folders is working, there are some inconsistencies with the `nsf` sync type:

<img width="616" alt="Screen Shot 2019-05-20 at 1 27 58 PM" src="https://user-images.githubusercontent.com/8559654/58040327-438dde00-7b03-11e9-86a5-1d39d8fef2a3.png">

This PR improves the sync option by updating the vagrant sync type to `virtualbox`.

For this option to work, the vagrant plugin `vbguest` needs to be installed on the host machine:
```
vagrant plugin install vagrant-vbguest
```