### PR TITLE
pycurl replaced with urllib2, BytesIO no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,16 +125,7 @@ The Fabric tools require a few python libraries that might not be installed on y
 
 ```bash
 pip3 install fabric3
-pip3 install pycurl
 ```
-
-On macOSX, you will also need pycurl - and therefore, pip  - for python2 on macOSX, it is reccomended not to use system python2 for this. Homebrew's python2 comes with `pip` preinstalled.
-
-```bash
-brew install python@2
-```
-
-On Mac OSX, issues with PyCurl can be addressed with the procedures described at [Installing PycURL on macOS High Sierra](https://cscheng.info/2018/01/26/installing-pycurl-on-macos-high-sierra.html), this affects both `python2` and `python3` so run with both `pip` and `pip3`.
 
 
 ### Configure Fabric for the Virtual Machine
@@ -157,14 +148,6 @@ If you have a REDCap zip file, say redcap7.2.2.zip, you can deploy it to the loc
 fab vagrant server_setup
 fab vagrant package:redcap7.2.2.zip
 fab vagrant delete_all_tables deploy:redcap-7.2.2.tgz
-```
-
-If running `fab vagrant delete_all_tables deploy:redcap-7.2.2.tgz` fails with the error  
-`libcurl link-time ssl backend (none/other) is different from compile-time ssl backend (openssl)`  
-try reinstalling pycurl with the following command and retrying.
-
-```bash
-PYCURL_SSL_LIBRARY=openssl LDFLAGS="-L/usr/local/opt/openssl/lib" CPPFLAGS="-I/usr/local/opt/openssl/include" pip install --no-cache-dir --compile --ignore-installed --install-option="--with-openssl" --global-option="--with-openssl" pycurl
 ```
 
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,8 +1,11 @@
 import unittest
-import pycurl
 import sys
-from io import BytesIO
 import re
+
+try:
+    from urllib.request import urlopen # Python3
+except ImportError:
+    from urllib2 import urlopen # Python2
 
 class Weburl():
 
@@ -11,14 +14,9 @@ class Weburl():
 
     def get(self, URL, FOLLOWLOCATION = False):
         self.URL = URL
-        buffer = BytesIO()
-        c = pycurl.Curl()
-        c.setopt(c.URL, URL)
-        c.setopt(c.WRITEDATA, buffer)
-        c.setopt(pycurl.FOLLOWLOCATION, FOLLOWLOCATION)
-        c.perform()
-        c.close()
-        return buffer.getvalue().decode('UTF-8').replace('\r\n', '').replace('\n', '')
+        response = urlopen(URL)
+        return response.read().decode('UTF-8').replace('\r\n', '').replace('\n', '')
+
 
 class UnauthenticatedAccessTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Did not see `import pycurl` in any other `.py` files, but didn't change the requirement in the readme in case it's needed by fabric elsewhere.