### PR TITLE
use default browser when auto-opening site for vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,7 +45,7 @@ Vagrant.configure(2) do |config|
 
   # Help the developer to find the app :)
   config.trigger.after [:up] do
-    system("open -a 'Google Chrome.app' #{ENV['URL_OF_DEPLOYED_APP']}")
+    system("open #{ENV['URL_OF_DEPLOYED_APP']}")
   end
 
 end


### PR DESCRIPTION
Probably not relevant anymore now that we've switched to Docker, but the constant launching of Chrome was annoying me here in Firefox land.