### PR TITLE
Test that version match is not None in apply_incremental_db_changes()

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,36 @@ Restart apache when you are done
 sudo service apache2 restart
 ```
 
+## Failed SQL upgrades
+
+If an upgrade operation fails on a `.php` or a `.sql` file, the code will die like this:
+
+```
+[redcap.ctsi.ufl.edu] run: php /var/https/redcap/redcap_v14.1.3/generate_upgrade_sql_from_php.php /var/https/redcap/redcap_v14.1.3/Resources/sql/upgrade_14.01.01.php | mysql
+[redcap.ctsi.ufl.edu] out: ERROR 1553 (HY000) at line 5: Cannot drop index 'redcap_userid': needed in a foreign key constraint
+[redcap.ctsi.ufl.edu] out: 
+
+
+Fatal error: run() received nonzero return code 1 while executing!
+
+Requested: php /var/https/redcap/redcap_v14.1.3/generate_upgrade_sql_from_php.php /var/https/redcap/redcap_v14.1.3/Resources/sql/upgrade_14.01.01.php | mysql
+Executed: /bin/bash -l -c "php /var/https/redcap/redcap_v14.1.3/generate_upgrade_sql_from_php.php /var/https/redcap/redcap_v14.1.3/Resources/sql/upgrade_14.01.01.php | mysql"
+
+Aborting.
+Disconnecting from deploy@redcap.ctsi.ufl.edu... done.
+```
+
+To fix this, you need to run that last PHP command to get the SQL statements that caused the issue. e.g.,
+
+```bash
+php /var/https/redcap/redcap_v14.1.3/generate_upgrade_sql_from_php.php /var/https/redcap/redcap_v14.1.3/Resources/sql/upgrade_14.01.01.php
+```
+
+You could all generate all of the SQL upgrade commands by access the Upgrade page in the Control Center.
+
+However you do it, paste that SQL upgrade commands into a MySQL Workbench window connected to the right database and run the lines one-by-one to debug the failure. If the fix is not obvious, check the REDCap community. Finish by running the last three statements from the Upgrade page in the Control Center.
+
+Put the host back online via the Control Center _General Configuration_ page. Then check the Control Center _Configuration Check_ age for any SQL commands that still need to be applied.
 
 ## Developer notes
 

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Aborting.
 Disconnecting from deploy@redcap.ctsi.ufl.edu... done.
 ```
 
-At this point things get messy and you will have to get creative in your problem solving. What follows is not a recipe. It's more like a pile of ingredients from which you could make an omlete. It's still your responsbility cook them right and not burn the omlete, because your gonna have to eat it.
+At this point things get messy and you will have to get creative in your problem solving. What follows is not a recipe. It's more like a pile of ingredients from which you could make an omelette. It's still your responsibility cook them right and not burn the omelette, because you're gonna have to eat it.
 
 ### Debugging
 
@@ -342,14 +342,14 @@ You can see the output of the script/SQl file that caused the by running that PH
 php /var/https/redcap/redcap_v14.1.3/generate_upgrade_sql_from_php.php /var/https/redcap/redcap_v14.1.3/Resources/sql/upgrade_14.01.01.php
 ```
 
-Running the SQL lines in that file one by one might help you understand which one failed. It's challenging because some of those commands will fail because they _did_ run successfully the first time, but they will error the second time. This often happens when a SQL command added an object that cannot be "re-added". Think carefully about the responses you see when running each command. Read the REDCap commuunity forum to see if others have experienced the errors you see and have a solution.
+Running the SQL lines in that file one by one might help you understand which one failed. It's challenging because some of those commands will fail because they _did_ run successfully the first time, but they will error the second time. This often happens when a SQL command added an object that cannot be "re-added". Think carefully about the responses you see when running each command. Read the REDCap community forum to see if others have experienced the errors you see and have a solution.
 
-Even if that task goes well and you can apply the file that failed there might be more files to run after that one. You can locate those by enumerating the files in the redcap_vN.M.O/Resources/sql/" directory. Look for versioned file names that are higher than the version number on which the script failed. If this seems tedious, you might want to try the next procedure.
+Even if that task goes well and you can apply the file that failed there might be more files to run after that one. You can locate those by enumerating the files in the `redcap_vN.M.O/Resources/sql/` directory. Look for versioned file names that are higher than the version number on which the script failed. If this seems tedious, you might want to try the next procedure.
 
 
 ### Ask REDCap to help you
 
-Another approach is to generate all of the SQL upgrade commands between the version you are at and the version you are upgrading to by accessing the Upgrade page in the Control Center. It will make the whole blob, running the PHP scripts, concatenating their output with the SQL files and appending the lines that document the upgrade. All that's pretty useful. Do be aware that every SQL line that succeeded will still be in the blob of SQL the Control Center Upgrade page generates for you. It's more content to to wade through, but it's all in one file with the last three "upgrade event" statements. 
+Another approach is to generate all of the SQL upgrade commands between the version you are at and the version you are upgrading to by accessing the Upgrade page in the Control Center. It will make the whole blob, running the PHP scripts, concatenating their output with the SQL files and appending the lines that document the upgrade. All that's pretty useful. Do be aware that every SQL line that succeeded will still be in the blob of SQL the Control Center Upgrade page generates for you. It's more content to wade through, but it's all in one file with the last three "upgrade event" statements.
 
 If you think you are done with the upgrade process, put the host back online via the Control Center _General Configuration_ page. Then check the Control Center _Configuration Check_ age for any SQL commands that still need to be applied. 
 

--- a/README.md
+++ b/README.md
@@ -332,17 +332,26 @@ Aborting.
 Disconnecting from deploy@redcap.ctsi.ufl.edu... done.
 ```
 
-To fix this, you need to run that last PHP command to get the SQL statements that caused the issue. e.g.,
+At this point things get messy and you will have to get creative in your problem solving. What follows is not a recipe. It's more like a pile of ingredients from which you could make an omlete. It's still your responsbility cook them right and not burn the omlete, because your gonna have to eat it.
+
+### Debugging
+
+You can see the output of the script/SQl file that caused the by running that PHP command or catting out that SQL file that failed. e.g.,
 
 ```bash
 php /var/https/redcap/redcap_v14.1.3/generate_upgrade_sql_from_php.php /var/https/redcap/redcap_v14.1.3/Resources/sql/upgrade_14.01.01.php
 ```
 
-You could all generate all of the SQL upgrade commands by access the Upgrade page in the Control Center.
+Running the SQL lines in that file one by one might help you understand which one failed. It's challenging because some of those commands will fail because they _did_ run successfully the first time, but they will error the second time. This often happens when a SQL command added an object that cannot be "re-added". Think carefully about the responses you see when running each command. Read the REDCap commuunity forum to see if others have experienced the errors you see and have a solution.
 
-However you do it, paste that SQL upgrade commands into a MySQL Workbench window connected to the right database and run the lines one-by-one to debug the failure. If the fix is not obvious, check the REDCap community. Finish by running the last three statements from the Upgrade page in the Control Center.
+Even if that task goes well and you can apply the file that failed there might be more files to run after that one. You can locate those by enumerating the files in the redcap_vN.M.O/Resources/sql/" directory. Look for versioned file names that are higher than the version number on which the script failed. If this seems tedious, you might want to try the next procedure.
 
-Put the host back online via the Control Center _General Configuration_ page. Then check the Control Center _Configuration Check_ age for any SQL commands that still need to be applied.
+
+### Ask REDCap to help you
+
+Another approach is to generate all of the SQL upgrade commands between the version you are at and the version you are upgrading to by accessing the Upgrade page in the Control Center. It will make the whole blob, running the PHP scripts, concatenating their output with the SQL files and appending the lines that document the upgrade. All that's pretty useful. Do be aware that every SQL line that succeeded will still be in the blob of SQL the Control Center Upgrade page generates for you. It's more content to to wade through, but it's all in one file with the last three "upgrade event" statements. 
+
+If you think you are done with the upgrade process, put the host back online via the Control Center _General Configuration_ page. Then check the Control Center _Configuration Check_ age for any SQL commands that still need to be applied. 
 
 ## Developer notes
 

--- a/upgrade.py
+++ b/upgrade.py
@@ -88,17 +88,17 @@ def apply_incremental_db_changes(old, new):
     path_to_sql_generation = '/'.join([env.live_pre_path, env.project_path, 'redcap_v' + new, 'generate_upgrade_sql_from_php.php'])
     for file in files.splitlines():
         match = re.search(r"(upgrade_)(\d+.\d+.\d+)(.)(php|sql)", file)
-        version = match.group(2)
-        version = utility.convert_version_to_int(version)
-        if version > old and version <= new_as_an_int:
-            if fnmatch.fnmatch(file, "*.php"):
-                print((file + " is a php file!\n"))
-                with settings(user=env.deploy_user):
-                    run('php %s %s | mysql' % (path_to_sql_generation,file))
-            else:
-                print(("Executing sql file %s" % file))
-                with settings(user=env.deploy_user):
-                    run('mysql < %s' % file)
+        if match is not None:
+            version = utility.convert_version_to_int(match.group(2))
+            if version > old and version <= new_as_an_int:
+                if fnmatch.fnmatch(file, "*.php"):
+                    print((file + " is a php file!\n"))
+                    with settings(user=env.deploy_user):
+                        run('php %s %s | mysql' % (path_to_sql_generation,file))
+                else:
+                    print(("Executing sql file %s" % file))
+                    with settings(user=env.deploy_user):
+                        run('mysql < %s' % file)
     # Finalize upgrade
     utility_redcap.set_redcap_config('redcap_last_install_date', datetime.now().strftime("%Y-%m-%d"))
     utility_redcap.set_redcap_config('redcap_version', new)


### PR DESCRIPTION
This fix addresses an issue caused by the addition of this file to REDCap core:

```
redcap_v14.1.3/Resources/sql/upgrade_CDP-bugfix.sql
```

`re.search(r"(upgrade_)(\d+.\d+.\d+)(.)(php|sql)", file)` was returning `None` on that file.